### PR TITLE
Improve files, faster load recursive folders

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -45,14 +45,11 @@ function activate(context) {
       newFileWhitelist.splice(newFileWhitelist.indexOf(pathUtil.normalize(event.fsPath)), 1);
       return;
     }
-    output(event.fsPath);
-    output(newFileWhitelist);
     newFiles.push(event.fsPath);
   });
   
   vscode.workspace.onDidSaveTextDocument(function(event){
     //console.log("onDidSaveTextDocument : ", event);
-    output("asdf");
     updateToRemoteTempPath(event.fileName);
   });
   vscode.workspace.onDidCloseTextDocument(function(event){
@@ -125,8 +122,6 @@ function activate(context) {
           }
           else  //new file
           {
-            output(newFiles);
-            output("uplooooad");
             newFiles.splice(newFiles.indexOf(event.document.uri.fsPath), 1);
             ftp.upload(remoteTempPath, ftpConfigFromTempDir.path, function (err) {
               if (err) output("upload fail : " + ftpConfigFromTempDir.path + " => " + err.message);
@@ -1159,8 +1154,7 @@ function upload(ftp, ftpConfig, localPath, remotePath, backupName, cb){
       main(isDir);
     });
   }
-  function main(isDir) {
-    output("upload1");
+  function main(isDir){
     ftp.upload(localPath, remotePath, function(err){
       // if(!err && !isForceUpload)
       // {
@@ -1504,8 +1498,7 @@ function updateToRemoteTempPath(remoteTempPath, existCheck, cb){
       function main(){
         remoteRefreshStopFlag = true;
         setTimeout(function(){
-          backup(ftp, ftpConfig.config, ftpConfig.path, function (err) {
-            output("upload2");
+          backup(ftp, ftpConfig.config, ftpConfig.path, function(err){
             ftp.upload(remoteTempPath + (isDir ? "/**" : ""), ftpConfig.path, function(err){
               remoteRefreshStopFlag = false;
               if(err) output("upload fail : " + ftpConfig.path + " => " + err);


### PR DESCRIPTION
Improve new file detection, keep files loaded when switching files, load placeholders for folders for remote directory. This potentially fixes #16, #19, #25, #30, and #34.

For new file detection, I used Visual Studio Code's [FileSystemWatcher](https://code.visualstudio.com/docs/extensionAPI/vscode-api#FileSystemWatcher) and removed the chokidar fswatcher.
I decided to remove your code that deletes the files when you switch to a different one, because it adds unnecessary file downloading and could potentially overwrite it (with nothing) if you save in between saving. I have lost my work multiple times because of this.
Instead of recursively downloading every single file at once, I saved them as a placeholder file (the folder foo would become the file @foo). When the user opens the file, it is automatically closed and deleted, and the file information in that folder is downloaded.