### PR TITLE
Ask passphrase on prompt

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -777,6 +777,30 @@ function destroy(isStart){
   // }
   fse.remove(REMOTE_TEMP_PATH, function(){});
 }
+function getPassphrase(ftpConfig, cb){
+  fs = require('fs');
+  fs.readFile(ftpConfig.privateKey, 'utf8', function(err, data){
+    if(err){
+      output("Cannot read the private key: " + ftpConfig.prirvateKey);
+    }
+    else
+    {
+      if(data.includes('ENCRYPTED') || (data.includes('PuTTY') && !data.includes('Encryption: none'))){
+        vsUtil.input({password: true, placeHolder: 'Enter the passphrase'}).then(function(item){
+          if(item){
+            ftpConfig.passphrase = item;
+            if(cb) cb();
+          }
+          else closeFTP(ftpConfig.host);
+        }); 
+      }
+      else if(cb)
+      {
+        cb();
+      }
+    }
+  });
+}
 function getPassword(ftpConfig, cb){
   if(!ftpConfig.password && !ftpConfig.privateKey)
   {
@@ -788,6 +812,10 @@ function getPassword(ftpConfig, cb){
       }
       else closeFTP(ftpConfig.host);
     });
+  }
+  else if(ftpConfig.privateKey && !ftpConfig.passphrase)
+  {
+    getPassphrase(ftpConfig, cb);
   }
   else if(cb)
   {


### PR DESCRIPTION
#87 It asks the passphrase on prompt when,
- the private key is encrypted
- while passphrase is not given in the config file.

The encryption checking code is not so beautiful (strict string comparison), but it works somehow as of now. :sweat_smile: Please let me know if it is too dangerous to read the private key at that point, or there are some other issues I am missing.